### PR TITLE
feat(command): add a separate db-reset command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,15 @@ YARN = yarn
 
 ##
 ## Database
-.PHONY: db db-cache fixtures
+.PHONY: db db-reset db-cache fixtures
 
-db: vendor ## Reset database and load fixtures
+db: vendor db-reset fixtures ## Reset database and load fixtures
+
+db-reset: ## Reset database
 	@$(EXEC_PHP) php -r 'echo "Wait database...\n"; set_time_limit(30); require __DIR__."/config/bootstrap.php"; $$u = parse_url($$_ENV["DATABASE_URL"]); for(;;) { if(@fsockopen($$u["host"].":".($$u["port"] ?? 3306))) { break; }}'
 	@-$(SYMFONY) doctrine:database:drop --if-exists --force
 	@-$(SYMFONY) doctrine:database:create --if-not-exists
 	@$(SYMFONY) doctrine:schema:update --force
-	@$(SYMFONY) doctrine:fixtures:load --no-interaction
 
 db-cache: ## Clear doctrine database cache
 	@$(SYMFONY) doctrine:cache:clear-metadata


### PR DESCRIPTION
Add a new `db-reset` command which resets the database without loading fixtures, while the original `db` command keeps the same behavior.